### PR TITLE
Add optional SHA-256 checksum verification

### DIFF
--- a/FolderCompareCLI/Enums/HashType.cs
+++ b/FolderCompareCLI/Enums/HashType.cs
@@ -1,0 +1,8 @@
+namespace FolderCompareCLI.Enums;
+
+public enum HashType
+{
+    Md5,
+    Sha256,
+    None
+}

--- a/FolderCompareCLI/Program.cs
+++ b/FolderCompareCLI/Program.cs
@@ -10,9 +10,13 @@ public class Program
     Source : source path for comparison
     Destination: destination path for comparison
     
-    Flags
-        -hash enables hash check using md5 (off by default), can only have 1 hash enabled
-        -hash256 enables hash check using sha256 (off by default), can only have 1 hash enabled
+
+    Hash Options, Hashing is off by default as it is slower and for most files Size will work
+    (only can hash type can run at a time):
+    
+        Flags
+        -hash enables hash check using md5 (off by default)
+        -hash256 enables hash check using sha256 (off by default)
 ";
 
     private static Dictionary<Guid, DifferenceNodeView> _differenceNodeViews = null;

--- a/FolderCompareCLI/Utils/FileAndIoUtils.cs
+++ b/FolderCompareCLI/Utils/FileAndIoUtils.cs
@@ -9,13 +9,19 @@ internal static class FileAndIoUtils
     public static char DirectorySeparator => _directorySeparatorStr ??
                                              (_directorySeparatorStr = Path.Combine("4", "4").Replace("4", "")
                                                  .First()).Value;
+    
+    public static string CalculateMd5(string filename) =>
+        CalculateHash(filename, stream => MD5.Create().ComputeHash(stream));
+    
+    public static string CalculateSha256(string filename) =>
+        CalculateHash(filename, stream =>  SHA256.Create().ComputeHash(stream));
 
-    public static string CalculateMd5(string filename)
+
+    private static string CalculateHash(string fileName, Func<Stream, byte[]> func)
     {
-        using var md5 = MD5.Create();
-        using var stream = File.OpenRead(filename);
-        var hash = md5.ComputeHash(stream);
-        return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        using var stream = File.OpenRead(fileName);
+        var hash = func(stream);
+        return BitConverter.ToString(hash).Replace("-", "");
     }
 
     private static readonly string[] Suffix = { "B", "KB", "MB", "GB", "TB", "PB", "EB" }; //Longs run out around EB
@@ -30,7 +36,9 @@ internal static class FileAndIoUtils
         return (Math.Sign(byteCount) * num).ToString() + Suffix[place];
     }
 
-    public static string GetRelativePath(string fullPath, string startingPoint) => fullPath.StartsWith(startingPoint) ? fullPath[(startingPoint.Length)..].TrimStart(DirectorySeparator).TrimEnd(DirectorySeparator) : fullPath;
+    public static string GetRelativePath(string fullPath, string startingPoint) => fullPath.StartsWith(startingPoint)
+        ? fullPath[(startingPoint.Length)..].TrimStart(DirectorySeparator).TrimEnd(DirectorySeparator)
+        : fullPath;
 
     public static void DirectoryCopy(string sourceDirName, string destDirName)
     {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ Folder Compare Cli is similar to my Folder Compare but with out the overhead of 
 <p>Arguments required expected args: {Source}  {Destination} {flags}</p>
 <p>Source : source path for comparison</p>
 <p>Destination: destination path for comparison</p>
-<p> optional flag -hash enables hash check lot slower off by default</p>
+<br>
+<p> checking hash of files is off by default but can be enabled with optional flags</p>
+<p> optional flag -hash enables hash check using md5  off by default</p>
+<p> optional flag -hash256 enables hash check using sha256 off by default</p>
 
 
 


### PR DESCRIPTION
This update introduces an optional SHA-256 checksum verification feature. While most users may not need it, certain file types could be vulnerable to MD5 collision attacks, making SHA-256 a safer choice for ensuring file integrity.

    Default behavior: Continues to operate as normal.

    New option: Enable SHA-256 verification for enhanced security.
